### PR TITLE
Replace pnpm run build with esbuild invokation

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,8 +5,7 @@
   ],
   "postUpgradeTasks": {
     "commands": [
-      "pnpm install --frozen-lockfile",
-      "pnpm run build",
+      "pnpm exec esbuild src/action.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/index.js",
     ],
     "fileFilters": ["dist/index.js"],
     "executionMode": "branch"


### PR DESCRIPTION
In https://coveord.atlassian.net/browse/PES-2577, a regex was added to allowlist `pnpm exec esbuild*`, so use that directly